### PR TITLE
📏  adjusting header fonts to show progression

### DIFF
--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -24,22 +24,22 @@ article {
   }
 
   h1 {
-    font-size: 1.75em;
+    font-size: 1.6em;
   }
   h2 {
-    font-size: 1.5em;
+    font-size: 1.4em;
   }
   h3 {
-    font-size: 1.17em;
+    font-size: 1.2em;
   }
   h4 {
-    font-size: 1.12em;
+    font-size: 1em;
   }
   h5 {
-    font-size: 0.83em;
+    font-size: 0.925em;
   }
   h6 {
-    font-size: 0.75em;
+    font-size: 0.85em;
   }
 
   p code {


### PR DESCRIPTION
changes based on feedback that:
 * h1 size is too large
 * cannot tell difference between h3 & h4 headings
 
 Before:
 
![headings_before](https://user-images.githubusercontent.com/1473646/146795576-9ccba0c9-97a6-41b2-a201-1472ee7c6265.png)

 After:
 
![headings_after](https://user-images.githubusercontent.com/1473646/146795438-f93e8c29-9222-4e89-8066-8f9c5639f438.png)

 